### PR TITLE
Changes Verify Abstraction Name

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_library(BOOTLOADER STATIC
     abstraction/aes/aes.c
-    abstraction/verify/verify.c
+    abstraction/ecc/ecc.c
     abstraction/hold/hold.c
     abstraction/init/init.c
     abstraction/jump/jump.c
@@ -28,7 +28,7 @@ add_library(BOOTLOADER STATIC
 target_include_directories(BOOTLOADER PUBLIC
     ../
     abstraction/aes
-    abstraction/verify
+    abstraction/ecc
     abstraction/hold
     abstraction/init
     abstraction/jump

--- a/firmware/abstraction/ecc/ecc.c
+++ b/firmware/abstraction/ecc/ecc.c
@@ -4,7 +4,7 @@
  *****************************************************************************/
 
 /**************************************************************************//**
- * @file        verify.c
+ * @file        ecc.c
  *
  * @brief       Provides an abstraction layer for verifying firmware signatures
  *
@@ -12,48 +12,48 @@
  *
  * @date        2024-02-24
  *****************************************************************************/
-#include "verify.h"
+#include "ecc.h"
 
-#define VERIFY_CB_EXPAND(key, decrypt) \
+#define ECC_VERIFY_CB_EXPAND(key, decrypt) \
     .cb = { key, decrypt }
 
-BL_STATIC Verify_t verify =
+BL_STATIC ECC_t ecc =
 {
     NULL,
-    VERIFY_CFG(VERIFY_CB_EXPAND)
+    ECC_CFG(ECC_VERIFY_CB_EXPAND)
 };
 
-BL_Err_t Verify_Init(void)
+BL_Err_t ECC_Init(void)
 {
     BL_Err_t err = BL_EIO;
 
-    if (verify.cb.key && verify.cb.verify)
+    if (ecc.cb.key && ecc.cb.verify)
     {
         err = BL_OK;
     }
     return err;
 }
 
-BL_Err_t Verify_GetKey(void)
+BL_Err_t ECC_GetKey(void)
 {
     BL_Err_t err = BL_EINVAL;
-    verify.key = verify.cb.key();
-    if (verify.key)
+    ecc.key = ecc.cb.key();
+    if (ecc.key)
     {
         err = BL_OK;
     }
     return err;
 }
 
-BL_Err_t Verify_Decrypt(BL_UINT8_T *hash,
-                        BL_UINT8_T *signature)
+BL_Err_t ECC_Decrypt(BL_UINT8_T *hash,
+                     BL_UINT8_T *signature)
 {
     BL_Err_t err = hash && signature ? BL_EIO : BL_ENODATA;
     if (err == BL_EIO)
     {
-        err = verify.cb.verify(hash,
-                               signature,
-                               verify.key) ==
+        err = ecc.cb.verify(hash,
+                            signature,
+                            ecc.key) ==
             BL_TRUE ? BL_OK : BL_ERR;
     }
     return err;

--- a/firmware/abstraction/ecc/ecc.h
+++ b/firmware/abstraction/ecc/ecc.h
@@ -3,11 +3,11 @@
  * This code is licensed under MIT license (see LICENSE.txt for details)
  *****************************************************************************/
 
-#ifndef __BL_ASYMMETRIC_H
-#define __BL_ASYMMETRIC_H
+#ifndef __BL_ECC_H
+#define __BL_ECC_H
 
 /**************************************************************************//**
- * @file        verify.h
+ * @file        ecc.h
  *
  * @brief       Provides an abstraction layer for verify decryption used
  *              for validating firmware image signatures
@@ -18,10 +18,10 @@
  *****************************************************************************/
 #include "config.h"
 
-#define VERIFY_SIGNATURE_LENGTH 64
+#define ECC_SIGNATURE_LENGTH 64
 
-typedef BL_UINT8_T *(*Verify_Key_t)(void);
-typedef BL_BOOL_T (*Verify_Cb_t)(BL_UINT8_T *hash,
+typedef BL_UINT8_T *(*ECC_Key_t)(void);
+typedef BL_BOOL_T (*ECC_Cb_t)(BL_UINT8_T *hash,
                                  BL_UINT8_T *signature,
                                  BL_UINT8_T *key);
 
@@ -30,37 +30,37 @@ typedef struct
     BL_UINT8_T *key;
     struct
     {
-        Verify_Key_t key;
-        Verify_Cb_t verify;
+        ECC_Key_t key;
+        ECC_Cb_t verify;
     } cb;
-} Verify_t;
+} ECC_t;
 
 /**************************************************************************//**
- * @brief Initialize The Configured Verification Module
+ * @brief Initialize The Configured ECC Verification Module
  *
  * @return BL_Err_t
  *****************************************************************************/
-BL_Err_t Verify_Init(void);
+BL_Err_t ECC_Init(void);
 
 /**************************************************************************//**
- * @brief Get The Decryption Key
+ * @brief Get The ECC Decryption Key
  *
  * @return BL_Err_t
  *****************************************************************************/
-BL_Err_t Verify_GetKey(void);
+BL_Err_t ECC_GetKey(void);
 
 /**************************************************************************//**
- * @brief Decrypt Block Of Data
+ * @brief Decrypt Signature And Compare To Hash
  *
  * @details The API for getting the decryption key must be called before this.
  *
  * @param hash[in] calculated hash value
- * @param size[in] provided signature to validate
+ * @param signature[in] provided signature to validate
  *
  * @return BL_Err_t
  *****************************************************************************/
-BL_Err_t Verify_Decrypt(BL_UINT8_T *hash,
-                        BL_UINT8_T *signature);
+BL_Err_t ECC_Decrypt(BL_UINT8_T *hash,
+                     BL_UINT8_T *signature);
 
 
 #endif //__BL_ASYMMETRIC_H

--- a/firmware/config/config.h
+++ b/firmware/config/config.h
@@ -397,7 +397,7 @@ typedef enum
  *                        This function returns if the signature was verified.
  *
  *****************************************************************************/
-#define VERIFY_CFG(ENTRY)        \
+#define ECC_CFG(ENTRY)        \
 
 #endif // __CONFIG_H
 

--- a/firmware/interface/loader/loader.c
+++ b/firmware/interface/loader/loader.c
@@ -25,7 +25,7 @@
 #include "helper.h"
 #include "aes.h"
 #include "sha256.h"
-#include "verify.h"
+#include "ecc.h"
 
 #define LOADER_CHECK(s, f) s = loader_Check(s, f);
 
@@ -149,7 +149,7 @@ BL_STATIC BL_Err_t loader_Start(void)
     if((err = Table_GetPartition(PARTITION_CURRENT, &loader.node)) == BL_OK &&
         (err = NVM_GetSize(loader.node, &loader.size.partition)) == BL_OK &&
         (err = NVM_GetOperation(loader.node, &op)) == BL_OK &&
-        (err = Verify_GetKey()) == BL_OK &&
+        (err = ECC_GetKey()) == BL_OK &&
         (err = AES_SetKey()) == BL_OK)
     {
         if (op != NVM_NONE_OP)
@@ -255,7 +255,7 @@ BL_STATIC states_e loader_Finish(BL_Err_t *err)
 BL_STATIC BL_Err_t loader_Validate(void)
 {
     BL_Err_t err = BL_ERR;
-    if((err = Verify_Decrypt(loader.digest, loader.table.signature)) == BL_OK &&
+    if((err = ECC_Decrypt(loader.digest, loader.table.signature)) == BL_OK &&
             (err = Table_UpdatePartitions()) == BL_OK)
     {
         loader.clean = FLAG_SET;

--- a/firmware/interface/table/table.h
+++ b/firmware/interface/table/table.h
@@ -27,7 +27,7 @@
  * @date        2024-03-03
  *****************************************************************************/
 #include "config.h"
-#include "verify.h"
+#include "ecc.h"
 #include "nvm.h"
 #include "aes.h"
 
@@ -43,7 +43,7 @@ typedef struct __attribute__((__packed__))
     BL_UINT32_T reserved1;
     BL_UINT32_T crc;
     BL_UINT16_T reserved2;
-    BL_UINT8_T signature[VERIFY_SIGNATURE_LENGTH];
+    BL_UINT8_T signature[ECC_SIGNATURE_LENGTH];
     BL_UINT8_T iv[AES_IV_SIZE];
     BL_UINT8_T reserved3[16];
 } Table_Partition_t;

--- a/firmware/main/main.c
+++ b/firmware/main/main.c
@@ -1,5 +1,5 @@
 #include "aes.h"
-#include "verify.h"
+#include "ecc.h"
 #include "sha256.h"
 #include "systick.h"
 #include "serial.h"
@@ -22,7 +22,7 @@ int main(void)
 
     /* Initialize Abstract */
     AES_Init();
-    Verify_Init();
+    ECC_Init();
     SHA256_Init();
     Init_Init();
     Systick_Init();

--- a/firmware/test/interface/test_loader.c
+++ b/firmware/test/interface/test_loader.c
@@ -3,7 +3,7 @@
 #include "loader.h"
 #include "mock_table.h"
 #include "mock_nvm.h"
-#include "mock_verify.h"
+#include "mock_ecc.h"
 #include "mock_aes.h"
 #include "mock_sha256.h"
 #include "mock_buffer.h"
@@ -84,7 +84,7 @@ static void loader_StartHelper(bool pass)
     NVM_GetSize_IgnoreArg_size();
     NVM_GetSize_ReturnThruPtr_size(&partitionSize);
     NVM_GetOperation_ExpectAnyArgsAndReturn(BL_OK);
-    Verify_GetKey_ExpectAndReturn(BL_OK);
+    ECC_GetKey_ExpectAndReturn(BL_OK);
     AES_SetKey_ExpectAndReturn(BL_OK);
 }
 
@@ -143,6 +143,6 @@ static void loader_FinishHelper(void)
 
 static void loader_ValidateHelper(void)
 {
-    RUN_NVM_OP(Verify_Decrypt,);
+    RUN_NVM_OP(ECC_Decrypt,);
     Table_UpdatePartitions_ExpectAndReturn(BL_OK);
 }


### PR DESCRIPTION
Allows for more direct use of ECC naming scheme which will be used for validating signatures

resolves #49